### PR TITLE
Https route match for manifest file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   ],
   "content_scripts": [
     {
-      "matches": [ "http://app.pipefy.com/*" ],
+      "matches": [ "http://app.pipefy.com/*", "https://app.pipefy.com/*" ],
       "js": [ "pipefy.js" ]
     }
   ]


### PR DESCRIPTION
This enables the extension for pipefy again.
As of 13/05/2015 the app enabled TLS and disabled plain http.
